### PR TITLE
Disable node dragging and smooth graph updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
     const linkGroup = svg.append("g").attr("class", "links");
     const nodeGroup = svg.append("g").attr("class", "nodes");
 
+    // keep a persistent set of nodes/links so their positions are retained
+    let nodes = [];
+    let links = [];
+
     const simulation = d3.forceSimulation()
       .force("link", d3.forceLink().id(d => d.id).distance(80))
       .force("charge", d3.forceManyBody().strength(-200))
@@ -46,14 +50,10 @@
         .attr("stroke", d => colorFromSignal(d.r));
       links.merge(linksEnter);
 
-      const nodes = nodeGroup.selectAll("g")
+      const nodesSelection = nodeGroup.selectAll("g")
         .data(graph.nodes, d => d.id);
-      nodes.exit().remove();
-      const nodeEnter = nodes.enter().append("g")
-        .call(d3.drag()
-          .on("start", dragstarted)
-          .on("drag", dragged)
-          .on("end", dragended));
+      nodesSelection.exit().remove();
+      const nodeEnter = nodesSelection.enter().append("g");
       nodeEnter.append("circle")
         .attr("class", "node")
         .attr("r", 10);
@@ -61,11 +61,11 @@
         .attr("x", 12)
         .attr("y", 3)
         .text(d => d.id);
-      nodes.merge(nodeEnter);
+      nodesSelection.merge(nodeEnter);
 
       simulation.nodes(graph.nodes).on("tick", ticked);
       simulation.force("link").links(graph.links);
-      simulation.alpha(1).restart();
+      simulation.alpha(0.3).restart();
     }
 
     function ticked() {
@@ -83,38 +83,24 @@
       fetch('/data')
         .then(res => res.json())
         .then(json => {
-          const nodesMap = new Map();
-          const links = [];
+          // reuse existing node objects so positions are kept between updates
+          const nodesMap = new Map(nodes.map(n => [n.id, n]));
+          const newLinks = [];
           for (const [source, neighbors] of Object.entries(json)) {
             const srcId = Number(source);
-            nodesMap.set(srcId, { id: srcId });
+            if (!nodesMap.has(srcId)) nodesMap.set(srcId, { id: srcId });
             neighbors.forEach(n => {
               if (n.n > 0 && n.r < 0) {
-                nodesMap.set(n.n, { id: n.n });
-                links.push({ source: srcId, target: n.n, r: n.r });
+                if (!nodesMap.has(n.n)) nodesMap.set(n.n, { id: n.n });
+                newLinks.push({ source: srcId, target: n.n, r: n.r });
               }
             });
           }
-          updateGraph({ nodes: [...nodesMap.values()], links });
+          nodes = Array.from(nodesMap.values());
+          links = newLinks;
+          updateGraph({ nodes, links });
         })
         .catch(err => console.error('Failed to load data', err));
-    }
-
-    function dragstarted(event, d) {
-      if (!event.active) simulation.alphaTarget(0.3).restart();
-      d.fx = d.x;
-      d.fy = d.y;
-    }
-
-    function dragged(event, d) {
-      d.fx = event.x;
-      d.fy = event.y;
-    }
-
-    function dragended(event, d) {
-      if (!event.active) simulation.alphaTarget(0);
-      d.fx = null;
-      d.fy = null;
     }
 
     fetchData();


### PR DESCRIPTION
## Summary
- Preserve node positions between data refreshes to avoid layout jumps and reduce alpha on restart for smoother rendering.
- Remove mouse dragging behavior so nodes cannot be repositioned by users.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68919b332190832c9f29e55b7a9c14eb