### PR TITLE
Serve latest data from JSON file

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,14 +2,21 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 
-const data = JSON.parse(
-  fs.readFileSync(path.join(__dirname, "data.json"), "utf-8")
-);
-
 function requestListener(req, res) {
   if (req.url === "/data") {
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(data));
+    fs.readFile(
+      path.join(__dirname, "data.json"),
+      "utf-8",
+      (err, content) => {
+        if (err) {
+          res.writeHead(500);
+          res.end("Error loading data.json");
+        } else {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(content);
+        }
+      }
+    );
   } else if (req.url === "/" || req.url === "/index.html") {
     fs.readFile(path.join(__dirname, "index.html"), (err, content) => {
       if (err) {
@@ -42,4 +49,4 @@ if (require.main === module) {
   start();
 }
 
-module.exports = { start, data };
+module.exports = { start };

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
-const { start, data } = require('./server');
+const fs = require('fs');
+const path = require('path');
+const { start } = require('./server');
 
 (async () => {
   const server = await start(0); // random available port
@@ -14,7 +16,10 @@ const { start, data } = require('./server');
     const res = await fetch(`http://localhost:${port}/data`);
     assert.strictEqual(res.status, 200);
     const json = await res.json();
-    assert.deepStrictEqual(json, data);
+    const expected = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'data.json'), 'utf-8')
+    );
+    assert.deepStrictEqual(json, expected);
     console.log('Test passed');
   } catch (err) {
     console.error('Test failed', err);


### PR DESCRIPTION
## Summary
- Serve `/data` by reading `data.json` each request for live updates
- Update tests to load expected data directly from `data.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891bac14154832c9aa65d52ba554a00