### PR TITLE
Hide Leaflet attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,21 +22,22 @@
         color: red;
         font-size: 200%;
       }
+      .leaflet-control-attribution {
+        display: none !important;
+      }
     </style>
   </head>
   <body>
     <div id="map"></div>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
-      const map = L.map("map");
+      const map = L.map("map", { attributionControl: false });
       const markers = new Map();
       const lines = new Map();
       let initialized = false;
 
       L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
         maxZoom: 26,
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       }).addTo(map);
 
       function colorFromSignal(r) {


### PR DESCRIPTION
## Summary
- Disable Leaflet attribution control and hide attribution block so it doesn't appear on the map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfcdaabb8c83298c570f05a2c5e728